### PR TITLE
delete golang and ojichat

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,10 @@
 FROM jjanzic/docker-python3-opencv
 
 RUN apt-get update \
-    && apt-get install -y \
-        golang nodejs npm awscli
+    && apt-get install -y nodejs npm awscli
 
 RUN pip install slackbot Pillow
 RUN npm install -g tanzaku
-
-RUN go get -u github.com/greymd/ojichat; \
-    go get -u github.com/gyozabu/himechat-cli
 
 RUN mkdir -p slackbot/plugins
 COPY run.py slackbot

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,5 +10,4 @@ services:
       - .py.env
     volumes:
       - ./plugins:/slackbot/plugins
-
-
+      - ./plugins:/opt/build/slackbot/plugins


### PR DESCRIPTION
- とりあえずzenzen_wakaranaiだけならojichat, himechat-cliは不要なので消しました。
  - awscilもいらなかったかもです
- volumesは、/slackbotと/opt/build/slackbotの両方ないと動かなかったので追加